### PR TITLE
Point submission instructions to syscall.hackclub.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TerminalCraft is now indefinite. There is no fixed deadline currently listed for
 1. Fork this repository
 2. Create a new folder in the `submissions` directory with your project name
 3. Add your project files and a README.md explaining your project
-4. Submit your project on Hack Club Slack with the `/craftr` command
+4. Submit your project at https://syscall.hackclub.com/
 
 Your submission should include:
 - Source code

--- a/terminalcraft/app/page.tsx
+++ b/terminalcraft/app/page.tsx
@@ -89,8 +89,8 @@ export default function Home() {
         return hackclubFlag();
       }
       case "submit": {
-        window.open("https://airtable.com/appzR6MIcj5G9A2Fa/pag8jn2axMXOB2lid/form", "_blank");
-        return "Opening submission form in new tab...";
+        window.open("https://syscall.hackclub.com/", "_blank");
+        return "Opening submission page in new tab...";
       }
       case "slack": {
         window.open('https://hackclub.slack.com/archives/C08F58MT3GV', '_blank');
@@ -156,7 +156,7 @@ Get ready to build and publish your own terminal program and earn a hardware gra
 ## How to Get Involved:
 1. Join the #terminal-craft channel on Slack to ask questions, share progress, or just vibe
 2. Build something sick & ship it!
-3. Submit your project on Slack with the **/craftr** command for review!
+3. Submit your project at https://syscall.hackclub.com/ for review!
 4. Claim your $5/hour hardware grant if approved
 
 ### Reward:


### PR DESCRIPTION
## What changed

Updated the submission instructions to point people to the new submission site at https://syscall.hackclub.com/. They no longer reference the Airtable form or the `/craftr` Slack command.

Updated in three places:
- `terminalcraft/app/page.tsx` — the `submit` terminal command now opens https://syscall.hackclub.com/ instead of the Airtable form
- `terminalcraft/app/page.tsx` — the "How to Get Involved" step in `about.md`
- `README.md` — the "How to Submit" step

## Why

Submissions are moving to the new syscall.hackclub.com site, so the Airtable form and `/craftr` command should no longer be advertised.